### PR TITLE
Fix latex compilation and missing files

### DIFF
--- a/end_semester_report.tex
+++ b/end_semester_report.tex
@@ -56,7 +56,7 @@
 \begin{center}
 	\begin{tabular}{lll}
 		Name of the student & \hspace*{2cm} ID No. & \hspace*{2cm} Discipline \\ 
-		[Student Name] &\hspace*{2cm} [Student ID] &\hspace*{2cm} [Discipline] \\
+		{[Student Name]} &\hspace*{2cm} {[Student ID]} &\hspace*{2cm} {[Discipline]} \\
 	\end{tabular}
 \end{center}
 
@@ -78,8 +78,7 @@
 	\centerline{\bf Station of}
 	\vspace{0.5cm}
 \begin{figure}[ht]
-\epsfxsize=1.0in
-\centerline{\epsffile{logo.eps}}
+\centerline{\includegraphics[width=1.0in]{logo.eps}}
 \end{figure}
 
 	\centerline{\bf BIRLA INSTITUTE OF TECHNOLOGY \& SCIENCE, PILANI}
@@ -98,9 +97,9 @@
 			& \\
 			& \\
 			& \\
-			Station & \hspace*{3cm} [Centre] \\
+			Station & \hspace*{3cm} {[Centre]} \\
 			& \\
-			Duration &\hspace*{3cm} [Start Date] \\
+			Duration &\hspace*{3cm} {[Start Date]} \\
 			& \\
 			Date of submission & December 2024 \\
 			& \\
@@ -108,14 +107,14 @@
 			& for Industrial Automation \\
 			& \\
 			ID No., Name and Discipline of the student: & \\
-			& [Student ID], [Student Name] \\
-			& [Discipline] \\
+			& {[Student ID]}, {[Student Name]} \\
+			& {[Discipline]} \\
 			& \\
 			Name and Designation of the expert: & \\
-			& [Expert Name], [Designation] \\
+			& {[Expert Name]}, {[Designation]} \\
 			& \\
 			Name of the PS faculty member: & \\
-			& [Faculty Name] \\
+			& {[Faculty Name]} \\
 			& \\
 			Key words: & Robotics, Computer Vision, Machine Learning, \\
 			& Automation, SLAM, Object Detection \\


### PR DESCRIPTION
Fix LaTeX compilation errors by correcting bracket usage in tables and updating image inclusion.

Square brackets `[]` were being misinterpreted as optional arguments for LaTeX commands, leading to "Missing number" and "Illegal unit of measure" errors. Encasing them in curly braces `{}` ensures they are treated as literal text. Additionally, `\epsffile` was replaced with `\includegraphics` for more robust image handling, resolving "File not found" errors for the logo.