### PR TITLE
Fix LaTeX missing file errors

### DIFF
--- a/end_semester_report.tex
+++ b/end_semester_report.tex
@@ -78,8 +78,7 @@
 	\centerline{\bf Station of}
 	\vspace{0.5cm}
 \begin{figure}[ht]
-\epsfxsize=1.0in
-\centerline{\epsffile{logo.eps}}
+\centerline{\includegraphics[width=1.0in]{logo.eps}}
 \end{figure}
 
 	\centerline{\bf BIRLA INSTITUTE OF TECHNOLOGY \& SCIENCE, PILANI}

--- a/main.tex
+++ b/main.tex
@@ -1,0 +1,1 @@
+\input{end_semester_report.tex}


### PR DESCRIPTION
Fix LaTeX compilation errors by adding a main input file and updating image inclusion.

The compiler was looking for `main.tex` but the primary document was `end_semester_report.tex`. Additionally, the `\epsffile` command for `logo.eps` was causing issues with PDF conversion, which is resolved by using `\includegraphics`.